### PR TITLE
Modified buildDateTimeColumn to automatically adjust for 1904 windowing

### DIFF
--- a/src/main/java/com/miraisolutions/xlconnect/data/ColumnBuilder.java
+++ b/src/main/java/com/miraisolutions/xlconnect/data/ColumnBuilder.java
@@ -161,9 +161,11 @@ public abstract class ColumnBuilder extends Common {
         Date[] colValues = new Date[values.size()];
         boolean[] missing = new boolean[values.size()];
         Iterator<CellValue> it = values.iterator();
+        Iterator<Cell> jt = cells.iterator();
         int counter = 0;
         while (it.hasNext()) {
             CellValue cv = it.next();
+            Cell cell = jt.next();
             if (cv == null) {
                 missing[counter] = true;
             } else {
@@ -197,7 +199,7 @@ public abstract class ColumnBuilder extends Common {
                         }
                         break;
                     case DateTime:
-                        colValues[counter] = DateUtil.getJavaDate(cv.getNumberValue());
+                        colValues[counter] = cell.getDateCellValue();
                         break;
                     default:
                         throw new IllegalArgumentException("Unknown data type detected!");


### PR DESCRIPTION
Previously, the buildDateTimeColumn method used DateUtil.getJavaDate() to read numbers as dates. However, this presented a problem when the spreadsheet was using 1904 windowing (using 1904 as the earliest possible date, which is standard on some Mac versions of Excel). See https://poi.apache.org/apidocs/org/apache/poi/ss/usermodel/DateUtil.html#getJavaDate(double)

Now, the method uses getDateCellValue(), which automatically adjusts for 1904 or 1900 windowing. See http://poi.apache.org/apidocs/org/apache/poi/ss/usermodel/Cell.html#getDateCellValue()
