### PR TITLE
Custom/bump poi 4.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.miraisolutions</groupId>
     <artifactId>XLConnect</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>XLConnect</name>
     <url>http://www.mirai-solutions.com</url>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,12 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
 <!--            <exclusions>
                 <exclusion>
                     <groupId>org.apache.poi</groupId>

--- a/src/main/java/com/miraisolutions/xlconnect/Workbook.java
+++ b/src/main/java/com/miraisolutions/xlconnect/Workbook.java
@@ -1460,7 +1460,7 @@ public final class Workbook extends Common {
     }
 
     public int getLastRow(int sheetIndex) {
-        return Math.max(getSheet(sheetIndex).getLastRowNum(), 0);
+        return getSheet(sheetIndex).getLastRowNum();
     }
 
     public int getLastRow(String sheetName) {

--- a/src/main/java/com/miraisolutions/xlconnect/Workbook.java
+++ b/src/main/java/com/miraisolutions/xlconnect/Workbook.java
@@ -1460,7 +1460,7 @@ public final class Workbook extends Common {
     }
 
     public int getLastRow(int sheetIndex) {
-        return getSheet(sheetIndex).getLastRowNum();
+        return Math.max(getSheet(sheetIndex).getLastRowNum(), 0);
     }
 
     public int getLastRow(String sheetName) {

--- a/src/main/java/com/miraisolutions/xlconnect/integration/r/RWorkbookWrapper.java
+++ b/src/main/java/com/miraisolutions/xlconnect/integration/r/RWorkbookWrapper.java
@@ -471,7 +471,9 @@ public final class RWorkbookWrapper {
     }
 
     public int getLastRow(int sheetIndex) {
-        return workbook.getLastRow(sheetIndex);
+        int lastRow = Math.max(workbook.getLastRow(sheetIndex), 0);
+        //if (lastRow < 0) throw new IllegalStateException();
+        return lastRow;
     }
 
     public int getLastRow(String sheetName) {

--- a/src/main/java/com/miraisolutions/xlconnect/integration/r/RWorkbookWrapper.java
+++ b/src/main/java/com/miraisolutions/xlconnect/integration/r/RWorkbookWrapper.java
@@ -471,13 +471,11 @@ public final class RWorkbookWrapper {
     }
 
     public int getLastRow(int sheetIndex) {
-        int lastRow = Math.max(workbook.getLastRow(sheetIndex), 0);
-        //if (lastRow < 0) throw new IllegalStateException();
-        return lastRow;
+        return Math.max(workbook.getLastRow(sheetIndex), 0);
     }
 
     public int getLastRow(String sheetName) {
-        return workbook.getLastRow(sheetName);
+        return Math.max(workbook.getLastRow(sheetName), 0);
     }
 
     public int getLastColumn(int sheetIndex) {


### PR DESCRIPTION
Update to POI 4.1.2
Returns -1 instead of 0 for the last row of an empty sheet, we want to retain compatibility with previous 4.1.x