### PR TITLE
align "full schemas" dependency for 5.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
-            <artifactId>ooxml-schemas</artifactId>
-            <version>1.4</version>
+            <artifactId>poi-ooxml-full</artifactId>
+            <version>5.2.3</version>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
since POI 5, the `ooxml-schemas` dependency has been renamed and its version number aligned.
See 5.0.0 under https://poi.apache.org/changes.html
This did not have any impact, but now I'm using the pom.xml to check that the correct dependencies are downloaded in XLConnect (PR forthcoming).