### PR TITLE
revert to "new FileInputStream(...)" instead of Files.newInputStream(…)

### DIFF
--- a/src/main/java/com/miraisolutions/xlconnect/Workbook.java
+++ b/src/main/java/com/miraisolutions/xlconnect/Workbook.java
@@ -102,7 +102,7 @@ public final class Workbook {
          * NOTE: We are using a FileInputStream since otherwise using 'save' multiple times would cause
          * a JVM crash as described here: https://bz.apache.org/bugzilla/show_bug.cgi?id=53515
          */
-        this.workbook = WorkbookFactory.create(Files.newInputStream(excelFile.toPath()), password);
+        this.workbook = WorkbookFactory.create(new FileInputStream(excelFile), password);
         this.excelFile = excelFile;
         init();
     }
@@ -112,7 +112,7 @@ public final class Workbook {
          * NOTE: We are using a FileInputStream since otherwise using 'save' multiple times would cause
          * a JVM crash as described here: https://bz.apache.org/bugzilla/show_bug.cgi?id=53515
          */
-        this.workbook = WorkbookFactory.create(Files.newInputStream(excelFile.toPath()));
+        this.workbook = WorkbookFactory.create(new FileInputStream(excelFile));
         this.excelFile = excelFile;
         init();
     }
@@ -727,7 +727,7 @@ public final class Workbook {
         CellReference bottomRight = aref.getLastCell();
 
         int imageType = getImageType(imageFile);
-        InputStream is = Files.newInputStream(imageFile.toPath());
+        InputStream is = new FileInputStream(imageFile);
         byte[] bytes = IOUtils.toByteArray(is);
         int imageIndex = workbook.addPicture(bytes, imageType);
         is.close();

--- a/src/main/java/com/miraisolutions/xlconnect/Workbook.java
+++ b/src/main/java/com/miraisolutions/xlconnect/Workbook.java
@@ -37,7 +37,6 @@ import org.apache.poi.util.IOUtils;
 import org.apache.poi.xssf.usermodel.*;
 
 import java.io.*;
-import java.nio.file.Files;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -101,6 +100,7 @@ public final class Workbook {
         /*
          * NOTE: We are using a FileInputStream since otherwise using 'save' multiple times would cause
          * a JVM crash as described here: https://bz.apache.org/bugzilla/show_bug.cgi?id=53515
+         * TODO once we no longer support java 8, try again to switch to Files.newInputStream(excelFile.toPath()) 
          */
         this.workbook = WorkbookFactory.create(new FileInputStream(excelFile), password);
         this.excelFile = excelFile;
@@ -111,6 +111,7 @@ public final class Workbook {
         /*
          * NOTE: We are using a FileInputStream since otherwise using 'save' multiple times would cause
          * a JVM crash as described here: https://bz.apache.org/bugzilla/show_bug.cgi?id=53515
+         * TODO once we no longer support java 8, try again to switch to Files.newInputStream(excelFile.toPath()) 
          */
         this.workbook = WorkbookFactory.create(new FileInputStream(excelFile));
         this.excelFile = excelFile;
@@ -727,6 +728,7 @@ public final class Workbook {
         CellReference bottomRight = aref.getLastCell();
 
         int imageType = getImageType(imageFile);
+        // TODO once we no longer support java 8, try again to switch to Files.newInputStream(imageFile.toPath()) 
         InputStream is = new FileInputStream(imageFile);
         byte[] bytes = IOUtils.toByteArray(is);
         int imageIndex = workbook.addPicture(bytes, imageType);


### PR DESCRIPTION
To fix miraisolutions/xlconnect#212, I had to revert this particular part of #29. It is probably related to issues with the way the current directory is handled in the interop between R and java, and the effect on how `.toPath` is evaluated on a `File` instance.

In particular, see https://stackoverflow.com/questions/840190/changing-the-current-working-directory-in-java for how this is generally not well solved.